### PR TITLE
Make Simple Voice Chat optional

### DIFF
--- a/mods/simple-voice-chat.toml
+++ b/mods/simple-voice-chat.toml
@@ -11,3 +11,7 @@ hash = "1e81696490b306f2e26134ba0bea4c486153cedd"
 [update.modrinth]
 mod-id = "9eGKb6K1"
 version = "ClJ8ePwh"
+
+[option]
+optional = true
+default = true


### PR DESCRIPTION
This helps me play the server without having Simple Voice Chat because my Mac doesn't support the mod. Manually updating the pack is annoying